### PR TITLE
Allow remote access to Intu dashboard

### DIFF
--- a/etc/shared/www/js/TopicClient.js
+++ b/etc/shared/www/js/TopicClient.js
@@ -178,7 +178,7 @@ var TopicClient = (function () {
 	return {
 		getInstance: function() {
 			if(!instance) {
-				instance = createInstance('127.0.0.1', 9443);
+				instance = createInstance(location.hostname, location.port);
 			}
 
 			return instance;

--- a/etc/shared/www/js/component/audio/audio.html
+++ b/etc/shared/www/js/component/audio/audio.html
@@ -1,5 +1,5 @@
 <div draggable=true class="card">
-    <img class="card-img-top" src="http://localhost:9443/topics/fft" alt="Card image cap" style="width: 100%;max-height: 200px;">
+    <img class="card-img-top" src="../topics/fft" alt="Card image cap" style="width: 100%;max-height: 200px;">
     <div class="card-block text-pane" style="height: 200px;">
         <div class="conversation-wrapper" style="height: 80%;overflow-y: auto;">
             <p class="card-text text-left" ng-repeat="text in $root.textObjects" ng-model="text">{{ text.transcription }}</p>

--- a/etc/shared/www/js/component/camera/camera.html
+++ b/etc/shared/www/js/component/camera/camera.html
@@ -1,5 +1,5 @@
 <div draggable="true" class="card" style="box-shadow:none;">
-    <img height=270 src="http://localhost:9443/topics/sensor-{{ cameraName }}" id="intu-camera" />
+    <img height=270 src="../topics/sensor-{{ cameraName }}" id="intu-camera" />
     <div class="card-block text-pane" style="padding-top:10px;padding-bottom:10px;background-color: #E7EBEC;">
         <select style="float:left;" ng-options="camera as camera.m_SensorName for camera in cameraParams" ng-model="item" ng-change="update();" ng-init="item = cameraParams[0]" ></select>
         <a href="#image1" ng-click="$root.updateType('camera');"><img class="go-right" src="img/Icon_Expand.png" style="width: 20px;"></a>

--- a/etc/shared/www/js/partials/main.html
+++ b/etc/shared/www/js/partials/main.html
@@ -5,11 +5,11 @@
 				<span ng-if="$root.showFullScreen">
 					<div ng-switch="fullType">
 						<span ng-switch-when="camera">
-							<img style="width:75%;" src="http://localhost:9443/topics/sensor-Camera" />
+							<img style="width:75%;" src="../topics/sensor-Camera" />
 						</span>
 						<span ng-switch-when="audio">
 							<div class="card">
-								<img class="card-img-top" src="http://localhost:9443/topics/fft" alt="Card image cap" style="width: 100%; position:relative;">
+								<img class="card-img-top" src="../topics/fft" alt="Card image cap" style="width: 100%; position:relative;">
 								<div class="card-block text-pane" style="height: 500px;">
 									<div class="conversation-wrapper" style="overflow-y: auto;">
 										<p class="card-text text-left" ng-repeat="text in $root.textObjects" style="font-size:32px;">{{ text.transcription }}</p>


### PR DESCRIPTION
Eliminated all absolute representations of host/endpoint/port in Intu Web contents, and changed to relative form so that Intu dashboard can be accessed remotely.

This patch is effective on all platforms if we want to access Intu dashboard remotely, and mandatory if we want to configure Intu on Pepper.

Signed-off-by: Takao Moriyama <moriyama@jp.ibm.com>