### PR TITLE
Fix load path for libopencv_plugin.dylib

### DIFF
--- a/scripts/mac_scripts/run_self.sh
+++ b/scripts/mac_scripts/run_self.sh
@@ -52,7 +52,7 @@ while true; do
 
 	echo Running self..
 	ulimit -c unlimited
-	export LD_LIBRARY_PATH=${SELF_HOME}
+	export LD_LIBRARY_PATH=${SELF_HOME}:${SELF_HOME}/lib
 	cd "${SELF_HOME}"
 	./self_instance -P ${PLATFORM} "$@"
 	PREV_STATUS="$(echo $?)"


### PR DESCRIPTION
This is a solution for https://github.com/watson-intu/self/issues/25
Intu is failing to load libopencv_plugin.dylib from lib/ directory.

Signed-off-by: Takao Moriyama moriyama@jp.ibm.com